### PR TITLE
Fixing an import error in StockTradeRecordProcessor

### DIFF
--- a/src/com/amazonaws/services/kinesis/samples/stocktrades/processor/StockTradeRecordProcessor.java
+++ b/src/com/amazonaws/services/kinesis/samples/stocktrades/processor/StockTradeRecordProcessor.java
@@ -25,7 +25,7 @@ import com.amazonaws.services.kinesis.clientlibrary.exceptions.ShutdownException
 import com.amazonaws.services.kinesis.clientlibrary.exceptions.ThrottlingException;
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessor;
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer;
-import com.amazonaws.services.kinesis.clientlibrary.types.ShutdownReason;
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.ShutdownReason;
 import com.amazonaws.services.kinesis.model.Record;
 import com.amazonaws.services.kinesis.samples.stocktrades.model.StockTrade;
 


### PR DESCRIPTION
The StockTradeRecordProcessor has an import error - the ShutdownReason class of KCL has been moved.